### PR TITLE
[MARKENG-1052][c] simple integration for consuming pm-tech SDK w/ bff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 node_modules/
 .cache/
 public
+
+# Generated
+bff.json
+bff-data

--- a/bff.js
+++ b/bff.js
@@ -1,0 +1,113 @@
+const fs = require('fs');
+const sh = require('shelljs');
+const crypto = require('crypto');
+const pingWebHook = require('./scripts/pingWebHook');
+const fetchPmTech = require('./scripts/fetchPmTech');
+const { allow } = require('./package.json');
+
+const { pmTech: allowedPmTech } = allow;
+const delay = 1000;
+const runtime = {
+  pm: [''],
+};
+
+if (process.env.PM_TECH) {
+  sh.exec('mkdir -p public');
+
+  Object.keys(runtime).forEach((key) => {
+    if (runtime[key][0]) {
+      const fileBuffer = fs.readFileSync(runtime[key][0]);
+      const hashSum = crypto.createHash('sha1');
+      const ext = runtime[key][0]
+        .split('/')
+        .pop()
+        .split('.')
+        .pop();
+
+      hashSum.update(fileBuffer);
+
+      const hex = hashSum.digest('hex');
+
+      runtime[key].push(`_${hex}.${ext}`);
+
+      sh.exec(`cp ${runtime[key][0]} public/${runtime[key][1]}`);
+    }
+  });
+}
+
+const prefetch = async () => {
+  sh.exec('mkdir -p bff-data');
+  await pingWebHook();
+
+  let pmTech = '';
+
+  if (process.env.PM_TECH) {
+    pmTech = await fetchPmTech();
+
+    pmTech = pmTech;
+
+    sh.exec('mkdir -p public');
+
+    Object.keys(runtime).forEach((key) => {
+      if (runtime[key][0]) {
+        const fileBuffer = fs.readFileSync(runtime[key][0]);
+        const hashSum = crypto.createHash('sha1');
+        const ext = runtime[key][0]
+          .split('/')
+          .pop()
+          .split('.')
+          .pop();
+
+        hashSum.update(fileBuffer);
+
+        const hex = hashSum.digest('hex');
+
+        runtime[key].push(`_${hex}.${ext}`);
+
+        setTimeout(() => {
+          sh.exec(`cp ${runtime[key][0]} public/${runtime[key][1]}`);
+        }, delay);
+      }
+    });
+  }
+
+  /* eslint-disable */
+  const script = (process.env.PM_TECH
+      && `
+${pmTech}
+if (typeof window.pm.scalp !== 'function') {
+  window.pm.setScalp({
+    property: 'api-gateways'
+  });
+}
+window.pm.driveCampaignId();
+function isPmTechAllowed(documentLocationPathname) {
+  return ${allowedPmTech[0] === '*' ||
+    allowedPmTech.indexOf(documentLocationPathname) !== -1};
+}
+var d = 1000, int;
+var int = setInterval(function(){
+  if (document.body) {
+    window.pm.scalp(
+      'pm-analytics',
+      'load',
+      document.location.pathname
+    );
+    window.pm.trackClicks();
+    clearInterval(int);
+  }
+}, d);
+    `)
+    || `
+      console.info('Postman OSS');
+    `;
+  /* eslint-enable */
+
+  fs.writeFile('bff.json', JSON.stringify({ script }), (err) => {
+    if (err) {
+      throw err;
+    }
+  });
+};
+
+prefetch();

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,0 +1,18 @@
+const React = require('react');
+const bff = require('./bff.json');
+
+exports.onPreRenderHTML = ({ getHeadComponents, replaceHeadComponents }) => {
+  const headComponents = getHeadComponents();
+  const modifiedComponents = [...headComponents];
+
+  modifiedComponents.push(
+    React.createElement('script', {
+      key: 'pm',
+      dangerouslySetInnerHTML: {
+        __html: bff.script
+      }
+    })
+  );
+
+  replaceHeadComponents(modifiedComponents);
+};

--- a/package.json
+++ b/package.json
@@ -8,16 +8,20 @@
     "gatsby"
   ],
   "scripts": {
+    "bff": "node bff.js",
     "develop": "gatsby develop",
     "start": "gatsby develop",
     "build": "gatsby build",
     "serve": "gatsby serve",
-    "clean": "gatsby clean"
+    "clean": "gatsby clean",
+    "postinstall": "npm run bff"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/react-fontawesome": "^0.1.16",
+    "axios": "^0.21.1",
+    "base-64": "1.0.0",
     "bootstrap": "4.5",
     "gatsby": "next",
     "gatsby-cli": "^4.0.0-zz-next.5",
@@ -32,6 +36,7 @@
     "gatsby-transformer-remark": "next",
     "gatsby-transformer-yaml": "next",
     "jquery": "3.5.1",
+    "node-fetch": "2.6.1",
     "node-sass": "^6.0.1",
     "popper.js": "1.16.1",
     "react": "^17.0.1",
@@ -41,7 +46,14 @@
     "react-typography": "^0.16.20",
     "sanitize-html": "^2.5.1",
     "showdown": "^1.9.1",
+    "shelljs": "0.8.4",
+    "terser": "5.6.1",
     "typography": "0.16.19",
     "uuid": "^8.3.2"
+  },
+  "allow": {
+    "pmTech": [
+      "*"
+    ]
   }
 }

--- a/scripts/fetchPmTech.js
+++ b/scripts/fetchPmTech.js
@@ -1,0 +1,44 @@
+const base64 = require('base-64');
+const fs = require('fs');
+const path = require('path');
+const fetch = require('node-fetch');
+const sh = require('shelljs');
+const { minify } = require('terser');
+
+async function compress(t) {
+  const result = await minify(t, {});
+
+  return result;
+}
+
+const host = process.env.PM_TECH || '';
+
+const fetchPmTech = () => new Promise((resolve) => {
+  fetch(host).then((resp) => {
+    if (resp) {
+      resp.json().then((data) => {
+        const tag = data['api-gateways'];
+        const script = base64.decode(data.version[tag]);
+
+        compress(script).then((compressed) => {
+          sh.exec('mkdir -p bff-data');
+          sh.exec('touch bff-data/pmTech.js');
+
+          fs.writeFile(
+            path.join('bff-data', 'pmTech.js'),
+            compressed.code,
+            (er) => {
+              if (er) {
+                throw er;
+              }
+            },
+          );
+
+          resolve(compressed.code);
+        });
+      });
+    }
+  });
+});
+
+module.exports = fetchPmTech;

--- a/scripts/pingWebHook.js
+++ b/scripts/pingWebHook.js
@@ -1,0 +1,27 @@
+const axios = require('axios').default;
+
+require('dotenv').config({
+  path: `.env.${process.env.NODE_ENV}`,
+});
+
+const pingWebHook = () => new Promise((resolve) => {
+  const host = process.env.WEB_HOOK || null;
+  if (host) {
+    axios.get(process.env.WEB_HOOK)
+    .then(() => {
+      /* eslint-disable no-console */
+      console.info('Success ping web hook');
+      /* eslint-enable */
+      resolve();
+    })
+    .catch(err => {
+      console.log('There was an issue when pinging the `WEB_HOOK`')
+      resolve();
+    });
+  } else {
+    console.log('`WEB_HOOK` was not defined.. As a result the webhook was not pinged.')
+    resolve();
+  }
+});
+
+module.exports = pingWebHook;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2484,6 +2484,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base-64@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/base-64/-/base-64-1.0.0.tgz#09d0f2084e32a3fd08c2475b973788eee6ae8f4a"
+  integrity sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==
+
 base64-arraybuffer@0.1.4:
   version "0.1.4"
   resolved "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz"
@@ -6218,6 +6223,11 @@ internal-slot@^1.0.3:
     has "^1.0.3"
     side-channel "^1.0.4"
 
+interpret@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
+  integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
+
 invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz"
@@ -9388,6 +9398,13 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
+  dependencies:
+    resolve "^1.1.6"
+
 recursive-readdir@2.2.2:
   version "2.2.2"
   resolved "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz"
@@ -9740,7 +9757,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.20.0, resolve@^1.3.2:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.20.0, resolve@^1.3.2:
   version "1.20.0"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -10107,6 +10124,15 @@ shell-quote@1.7.2:
   resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
 
+shelljs@0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
+  integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
+
 showdown@^1.9.1:
   version "1.9.1"
   resolved "https://registry.npmjs.org/showdown/-/showdown-1.9.1.tgz"
@@ -10277,6 +10303,14 @@ source-map-support@^0.5.17, source-map-support@^0.5.20, source-map-support@~0.5.
   version "0.5.20"
   resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz"
   integrity sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map-support@~0.5.19:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -10802,6 +10836,15 @@ terser-webpack-plugin@^5.1.3, terser-webpack-plugin@^5.2.4:
     serialize-javascript "^6.0.0"
     source-map "^0.6.1"
     terser "^5.7.2"
+
+terser@5.6.1:
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.6.1.tgz#a48eeac5300c0a09b36854bf90d9c26fb201973c"
+  integrity sha512-yv9YLFQQ+3ZqgWCUk+pvNJwgUTdlIxUk1WTN+RnaFJe2L7ipG2csPT0ra2XRm7Cs8cxN7QXmK1rFzEwYEQkzXw==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.7.2"
+    source-map-support "~0.5.19"
 
 terser@^5.7.2:
   version "5.9.0"


### PR DESCRIPTION
**What are the changes?**
This uses a simple integration for bringing in the pm-tech SDK & configuring it with an assist from a bff script. Similar to the "Learning Center" _(postman-docs)_, to support open source development, two secrets will be required _(to be OSS friendly)_:
WEB_HOOK & PM_TECH

**Why make these changes?**
The SDK will collect data _(client-events)_ to be analyzed at a later point for insights.

![demo_api-gateways_pm-tech_pr](https://user-images.githubusercontent.com/56083362/144145928-12f8ffe8-07c5-45ce-a3ac-add804bb5112.gif)

