### PR TITLE
[MARKENG-1653][c] include e2e header in fetchPmTech script

### DIFF
--- a/scripts/fetchPmTech.js
+++ b/scripts/fetchPmTech.js
@@ -4,6 +4,13 @@ const path = require('path');
 const fetch = require('node-fetch');
 const sh = require('shelljs');
 const { minify } = require('terser');
+const requestOptions = {
+  method: 'GET',
+  headers: {
+    bff: 'e2e'
+  },
+  redirect: 'follow'
+};
 
 async function compress(t) {
   const result = await minify(t, {});
@@ -14,7 +21,7 @@ async function compress(t) {
 const host = process.env.PM_TECH || '';
 
 const fetchPmTech = () => new Promise((resolve) => {
-  fetch(host).then((resp) => {
+  fetch(host, requestOptions).then((resp) => {
     if (resp) {
       resp.json().then((data) => {
         const tag = data['api-gateways'];


### PR DESCRIPTION
**What are the changes?**
_Branched from `main`_, This includes the e2e header when fetching pmTech.

**Why make these changes?**
W/o the header, the response for the SDK will be empty